### PR TITLE
Improvements on command arguments

### DIFF
--- a/ExecuteOnSave.py
+++ b/ExecuteOnSave.py
@@ -44,7 +44,7 @@ class ExecuteOnSaveCommand(sublime_plugin.TextCommand):
         if saving and not build_on_save:
             return
 
-        for filter, execute in filter_execute:
+        for filter, args in filter_execute.iteritems():
             if re.search(filter, view.file_name()):
-                cmd = Template(execute).substitute(variables)
-                view.window().run_command("exec", {"cmd": cmd})
+                args['cmd'] = Template(args['cmd']).substitute(variables)
+                view.window().run_command("exec", args)

--- a/ExecuteOnSave.py
+++ b/ExecuteOnSave.py
@@ -1,6 +1,8 @@
 import sublime
 import sublime_plugin
 import re
+import os
+from string import Template
 
 
 class ExecuteOnSave(sublime_plugin.EventListener):
@@ -9,16 +11,40 @@ class ExecuteOnSave(sublime_plugin.EventListener):
 
 
 class ExecuteOnSaveCommand(sublime_plugin.TextCommand):
+    def expand_variables(self):
+        res = {
+            "packages": sublime.packages_path(),
+            "installed_packages": sublime.installed_packages_path()
+        }
+        window = self.view.window()
+        if window.folders():
+            res["folder"] = window.folders()[0]
+        av = window.active_view()
+        if av is None:
+            return res
+        filename = av.file_name()
+        if not filename:
+            return res
+        filename = os.path.abspath(filename)
+        res["file"] = filename
+        res["file_path"] = os.path.dirname(filename)
+        res["file_basename"] = os.path.basename(filename)
+        if 'folder' not in res:
+            res["folder"] = res["file_path"]
+        return res
+
     def run(self, edit, saving=False):
 
         view = self.view
         global_settings = sublime.load_settings(__name__ + '.sublime-settings')
         build_on_save = view.settings().get('build_on_save', global_settings.get('build_on_save', False))
         filter_execute = view.settings().get('filter_execute', global_settings.get('filter_execute', []))
+        variables = self.expand_variables()
 
         if saving and not build_on_save:
             return
 
         for filter, execute in filter_execute:
             if re.search(filter, view.file_name()):
-                view.window().run_command("exec", {"cmd": execute})
+                cmd = Template(execute).substitute(variables)
+                view.window().run_command("exec", {"cmd": cmd})

--- a/ExecuteOnSave.sublime-settings
+++ b/ExecuteOnSave.sublime-settings
@@ -1,7 +1,9 @@
 {
-    "filter_execute": [
-    	//["\\.js$", "/Users/myname/Sites/projects/coolproject/build.sh"],
-    	//["\\.as$", "/Users/myname/Sites/projects/coolproject/flash/build.sh"]
-    ],
-    "build_on_save": 0
+    {
+        "build_on_save": 0,
+            "filter_execute": {
+                "\\.js$": { "cmd": "/Users/username/Sites/projects/flow2/repo/build.sh" },
+                "\\.as$": { "cmd": "/Users/username/Sites/projects/flow2/repo/flash/build.sh" }
+            }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Do NOT edit the default ExecuteOnSave settings. Your changes will be lost when E
 Set to `1` to trigger a build on save. By default, this is set to `0`.
 
 * **filter_execute**
-Is an array that holds one array or multiple arrays with a length of 2. The first element is a regular expression that specifies on which files that are saved the command should be executed. The second element is the command that should be executed. Okay this sounds way too complicated, an example should clear this up.
+Is a dictionary that holds one or multiple paths along with its associated command executions. Each key is a regular expression that specifies on which files that are saved the command should be executed. The value is the args to the the command that should be executed. Okay this sounds way too complicated, an example should clear this up.
 
 Example project file:
 
@@ -54,10 +54,10 @@ Example project file:
 		"settings":
 		{
 			"build_on_save": 1,
-			"filter_execute":[
-				["\\.js$", "/Users/username/Sites/projects/flow2/repo/build.sh"],
-				["\\.as$", "/Users/username/Sites/projects/flow2/repo/flash/build.sh"]
-			]
+			"filter_execute": {
+				"\\.js$": { "cmd": "/Users/username/Sites/projects/flow2/repo/build.sh" },
+				"\\.as$": { "cmd": "/Users/username/Sites/projects/flow2/repo/flash/build.sh" }
+			}
 		}
 	}
 


### PR DESCRIPTION
Good idea luwes,

I've just been playing with your plugin the last two hours and made a couple of tweaks that might be of somebody else interest.

1. I needed a way to refer to the filename and location of the file being saved (#1). Resolved that by replacing commonly used variables listed in the command itself (folder, file, file_path and file_basename).
2. Changed the `filter_execute` node type so specify command options to the inner `exec` command. (see [Command Arguments](http://docs.sublimetext.info/en/latest/reference/build_systems/exec.html))

Hope it makes sense,

Regards,
